### PR TITLE
Remove (mc/save-lists)

### DIFF
--- a/smart-region.el
+++ b/smart-region.el
@@ -113,7 +113,5 @@ mark, it add cursor to each line (it call `mc/edit-lines')."
       (delq 'smart-region
             mc/cmds-to-run-for-all))
 
-(mc/save-lists)
-
 (provide 'smart-region)
 ;;; smart-region.el ends here


### PR DESCRIPTION
This line was causing an issue (resetting the mc-lists file) when interacting with flycheck. It's not needed to save the lists here because smart-region is setting the lists correctly when it's loaded. multiple-cursors will handle the rest.